### PR TITLE
Fix callback err, passport.authenticate() setup incorrectly

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const express = require("express");
 const session = require('express-session');
 const cors = require("cors");
 const axios = require("axios").create({
-  baseURL: 'https://www.strava.com/api/v3'
+    baseURL: 'https://www.strava.com/api/v3'
 })
 const passport = require("passport");
 //const StravaStrategy = require("passport-strava").Strategy;
@@ -42,43 +42,39 @@ passport.deserializeUser(function(obj, done) {
 
 // Strava Strategy
 passport.use(new StravaStrategy({
-  clientID: keys.STRAVA.CLIENT_ID,
-  clientSecret: keys.STRAVA.CLIENT_SECRET,
-  callbackURL: "/auth/strava/callback",
-  //callbackURL: "http://localhost:3000/auth/strava/callback",
-  //callbackURL: "http://mile37.com:3000/auth/strava/callback",
-  approvalPrompt: 'force'
-  },
+        clientID: keys.STRAVA.CLIENT_ID,
+        clientSecret: keys.STRAVA.CLIENT_SECRET,
+        callbackURL: "/auth/strava/callback",
+        //callbackURL: "http://localhost:3000/auth/strava/callback",
+        //callbackURL: "http://mile37.com:3000/auth/strava/callback",
+        approvalPrompt: 'force'
+    },
+    (accessToken, refreshToken, profile, cb) => {
+        console.log("Passport callback function fired");
+        //console.log(chalk.blue(JSON.stringify(profile)));
+        // put all of the key:value pairs from the profile into a 'user' object
+        user = { ...profile };
+        credentials = {accessToken, profile};
+        console.log('credentials: ', credentials);
 
-  
-  //RMB-YouTube Implementation                             
-  // callback function that will be run right after making request to Strava API
-  (accessToken, refreshToken, profile, cb) => {
-    console.log("Passport callback function fired");
-    //console.log(chalk.blue(JSON.stringify(profile)));
-    // put all of the key:value pairs from the profile into a 'user' object
-    user = { ...profile };
-    credentials = {accessToken, profile};
-    console.log('credentials: ', credentials);
-    
-    return cb(null, profile);
-  }));
+        return cb(null, profile);
+    }));
 
-  /*
-  //My own implementation
-  // the callback function that will fire
-  function(accessToken, refreshToken, profile, done) {
-    // asynchronous verification, for effect...
-    console.log('accessToken:', accessToken);
-    console.log('refreshToken:', refreshToken);
-    //console.log('profile:', profile);
-    //console.log(chalk.blue(JSON.stringify(profile)));
+/*
+//My own implementation
+// the callback function that will fire
+function(accessToken, refreshToken, profile, done) {
+  // asynchronous verification, for effect...
+  console.log('accessToken:', accessToken);
+  console.log('refreshToken:', refreshToken);
+  //console.log('profile:', profile);
+  //console.log(chalk.blue(JSON.stringify(profile)));
 
-    user = { ...profile };
-    credentials = {accessToken, profile};
-    console.log('credentials: ', credentials);
-  }
-  */
+  user = { ...profile };
+  credentials = {accessToken, profile};
+  console.log('credentials: ', credentials);
+}
+*/
 
 
 // setup the server
@@ -88,9 +84,9 @@ app.use(cors());
 app.use(require('cookie-parser')());
 app.use(require('body-parser').urlencoded({ extended: true }));
 app.use(session({
-  secret: keys.STRAVA.SESSION_SECRET,
-  resave: true,
-  saveUninitialized: true
+    secret: keys.STRAVA.SESSION_SECRET,
+    resave: true,
+    saveUninitialized: true
 }));
 app.use(passport.initialize());
 app.use(passport.session());
@@ -98,37 +94,28 @@ app.use(passport.session());
 // requiring a directory automatically pulls from the index.js that is in that directory
 //app.use(require('./routes');
 
-app.get('/auth/strava',
-  passport.authenticate('strava', { scope: ['read_all'] }),
-  // function(req, res) {
-  //   res.send("Did I make the auth request?");
-  //   // Request is redirected to Strava for authentication so this shouldn't be called
-  //   return;
-  // }
-  );
+app.get('/auth/strava', passport.authenticate('strava', { scope: ['read_all'] }));
 
-// define callback
 app.get("/auth/strava/callback",
-  passport.authenticate('strava', { failureRedirect: '/' }, { failWithError: true }),
+    passport.authenticate('strava', { failWithError: true, failureRedirect: '/' }),
     (req, res) => {
-      res.send("Did I make it here?");
-      res.redirect("/profile");
-   },
-   // this should act as an error handler...
-  function(err, req, res, next) {
-    return res.send({'status' : 'err', 'message':err.message});
-  });
+        console.log("returned to callback, about to redirect to profile page in app");
+        res.redirect("/profile");
+    },
+    function(err, req, res, next) {
+        return res.send({'status' : 'err', 'message':err.message});
+    });
 
 app.get("/user", (req, res) => {
-  console.log("getting user data");
-  res.send(user);
+    console.log("getting user data");
+    res.send(user);
 });
 
 // logout a user
 app.get("/auth/logout", (req, res) => {
-  console.log("logging out");
-  user = {};
-  res.redirect("/");
+    console.log("logging out");
+    user = {};
+    res.redirect("/");
 });
 
 const PORT = 5000;


### PR DESCRIPTION
The passport.authenticate() had 3 arguments passed into it, and the 3rd argument is used to set the callback functionality. So when you had the object { failWithError: ... } it was overriding the callback function and that's why you got your "callback is not a function" error.